### PR TITLE
docs: oneline cli tools installer 

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,27 +64,32 @@ cd ~/.claude
 
 **Core Tools:**
 
-- **Python 3.12+** - Hooks use stdlib only, no external packages required
 - **Node.js** - For Husky/lint-staged automation (`npm install`)
 - **Just** - Command runner for build scripts (`brew install just`)
+- **Python 3.12+**
+- [uv](https://github.com/astral-sh/uv) - Python package and project manager
 
 **Modern CLI Tools**:
 
-- [`fd`](https://github.com/sharkdp/fd) - Fast file finder (critical for settings merge)
-- [`jq`](https://github.com/jqlang/jq) - JSON processor (critical for settings merge)
-- [`gum`](https://github.com/charmbracelet/gum) - UI components for spinners
-- [`rg`](https://github.com/BurntSushi/ripgrep) (ripgrep) - Fast search
-- [`eza`](https://github.com/eza-community/eza) - Modern ls replacement
 - [`bat`](https://github.com/sharkdp/bat) - Modern cat replacement
 - [`delta`](https://github.com/dandavison/delta) - Git diff viewer
+- [`eza`](https://github.com/eza-community/eza) - Modern ls replacement
+- [`fd`](https://github.com/sharkdp/fd) - Fast file finder
 - [`fzf`](https://github.com/junegunn/fzf) - Fuzzy finder
 - [`gh`](https://github.com/cli/cli) - GitHub CLI
-- [`yq`](https://github.com/mikefarah/yq) - YAML processor
+- [`gum`](https://github.com/charmbracelet/gum) - UI components for spinners
+- [`jq`](https://github.com/jqlang/jq) - JSON processor
+- [`rg`](https://github.com/BurntSushi/ripgrep) (ripgrep) - Fast search
 - [`ruff`](https://github.com/astral-sh/ruff) - Python linter/formatter
-- [`uv`](https://github.com/astral-sh/uv) - Python package manager
+- [`yq`](https://github.com/mikefarah/yq) - YAML processor
+
+#### One-Line Installer
+
+On macOS, you can install all dependencies using Homebrew:
 
 ```bash
-brew install fd jq gum rg eza bat delta fzf gh yq ruff uv # After installation, follow shell integration steps for fzf
+# After installation, follow shell integration steps for fzf
+brew install bat delta eza fd fzf gh gum jq just rg ruff uv yq
 ```
 
 **Setup:**


### PR DESCRIPTION
This PR adds a oneline installer command under the CLI tools. It also includes `uv` in that area since it's a required install for `just merge-settings` to work.