### PR TITLE
fix(skills/typescript): remove double negation rule

### DIFF
--- a/skills/typescript/SKILL.md
+++ b/skills/typescript/SKILL.md
@@ -76,17 +76,6 @@ const tomorrow = now.add(1, "day");
 
 Never use the `any` type.
 
-### No double negation (`!!`)
-
-Do not use the double negation (`!!`) operator. Instead, use the `Boolean` constructor.
-
-**Example:**
-
-```typescript
-const x = !!y; // bad
-const x = Boolean(y); // good
-```
-
 ### No return value in `forEach` callbacks
 
 Never return a value from a `forEach` callback.


### PR DESCRIPTION
Removes the rule discouraging the `!!` operator in favor of Boolean() constructor.

The interruptions caused by this rule outweigh its small benefit in code style consistency.

> [!NOTE]
> This addresses the bash permission errors shown in the provided screenshots - the !! operator in markdown was causing issues, but more importantly, the rule itself was creating workflow friction.


<img width="300" src="https://github.com/user-attachments/assets/57b2dedb-4b9e-433c-987d-ca8f9308ffa2" />

<img width="450" src="https://github.com/user-attachments/assets/4989ba55-bf32-44fc-bb85-831f5841df34" />

